### PR TITLE
Fix streaming file upload to backend

### DIFF
--- a/frontend/pages/api/upload.js
+++ b/frontend/pages/api/upload.js
@@ -1,14 +1,30 @@
 import axios from 'axios';
 
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).end();
   try {
-    const { authorization } = req.headers;
-    const resp = await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/upload`, req.body, {
-      headers: { Authorization: authorization, 'Content-Type': req.headers['content-type'] },
-    });
+    const headers = { ...req.headers };
+    delete headers.host; // let axios set correct host
+    delete headers['content-length'];
+    delete headers['accept-encoding'];
+
+    const resp = await axios.post(
+      `${process.env.NEXT_PUBLIC_API_URL}/upload`,
+      req,
+      {
+        headers,
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity,
+      }
+    );
     res.status(resp.status).json(resp.data);
   } catch (e) {
-    res.status(500).json({ error: e.message });
+    res.status(e.response?.status || 500).json({ error: e.message });
   }
 }


### PR DESCRIPTION
## Summary
- disable body parsing for the upload API route
- pipe the incoming multipart stream directly to the backend

## Testing
- `npm --prefix frontend test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68753f5e41208323b021ae84b62ec129