### PR TITLE
Add login API proxy endpoints

### DIFF
--- a/frontend/pages/api/login/admin.js
+++ b/frontend/pages/api/login/admin.js
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const headers = { ...req.headers };
+  delete headers.host;
+  delete headers['content-length'];
+  delete headers['accept-encoding'];
+
+  try {
+    const resp = await axios.post(
+      `${process.env.NEXT_PUBLIC_API_URL}/login/admin`,
+      req.body,
+      { headers }
+    );
+    res.status(resp.status).json(resp.data);
+  } catch (e) {
+    res
+      .status(e.response?.status || 500)
+      .json(e.response?.data || { error: e.message });
+  }
+}

--- a/frontend/pages/api/login/customer.js
+++ b/frontend/pages/api/login/customer.js
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const headers = { ...req.headers };
+  delete headers.host;
+  delete headers['content-length'];
+  delete headers['accept-encoding'];
+
+  try {
+    const resp = await axios.post(
+      `${process.env.NEXT_PUBLIC_API_URL}/login/customer`,
+      req.body,
+      { headers }
+    );
+    res.status(resp.status).json(resp.data);
+  } catch (e) {
+    res
+      .status(e.response?.status || 500)
+      .json(e.response?.data || { error: e.message });
+  }
+}


### PR DESCRIPTION
## Summary
- proxy login API routes to the backend

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68760c97f69c83238867ceb1f1fce9cb