### PR TITLE
Switch login pages to use API calls

### DIFF
--- a/frontend/pages/login/admin.js
+++ b/frontend/pages/login/admin.js
@@ -9,8 +9,18 @@ export default function AdminLogin() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
-    if (!error) router.push('/upload');
+    const res = await fetch('/api/login/admin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.session) {
+        await supabase.auth.setSession(data.session);
+        router.push('/upload');
+      }
+    }
   };
 
   return (

--- a/frontend/pages/login/customer.js
+++ b/frontend/pages/login/customer.js
@@ -9,8 +9,18 @@ export default function CustomerLogin() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
-    if (!error) router.push('/gallery');
+    const res = await fetch('/api/login/customer', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.session) {
+        await supabase.auth.setSession(data.session);
+        router.push('/gallery');
+      }
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- update admin login page to call internal API instead of Supabase directly
- do the same for customer login page

## Testing
- `npm --prefix frontend test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68762430193c8323a8a685694d7301b1